### PR TITLE
Changing the priority of tooltip to LOW

### DIFF
--- a/src/main/java/com/tarinoita/solsweetpotato/client/TooltipHandler.java
+++ b/src/main/java/com/tarinoita/solsweetpotato/client/TooltipHandler.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.Item;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -22,7 +23,7 @@ import static com.tarinoita.solsweetpotato.lib.Localization.localizedComponent;
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = SOLSweetPotato.MOD_ID)
 public final class TooltipHandler {
-	@SubscribeEvent
+	@SubscribeEvent(priority = EventPriority.LOW)
 	public static void onItemTooltip(ItemTooltipEvent event) {
 		if (!SOLSweetPotatoConfig.isFoodTooltipEnabled()) return;
 		


### PR DESCRIPTION
The change will help with other modded tooltip compat, for example if you are using Serene Seasons with another version Slice Of Life like carrot edition. That will make all SoL tooltips stick together. As for mod standalone it will not change anything.